### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "popper.js": "^1.14.7",
     "node-sass": "^4.11.0",
     "sass-loader": "^7.1.0",
-    "npm": "^6.9.0",
     "vue": "^2.6.7"
   },
   "devDependencies": {


### PR DESCRIPTION

Hello HPDESIGNER!

It seems like you have npm as one of your (dev-) dependency in about-me.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
